### PR TITLE
## Release Notes for **GHRD for Arria 10 FPGA 25.3**

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is only applicable if the feature is enabled.
   - SGMII with HPS EMAC and Triple-Speed Ethernet Intel FPGA IP (PHY)
 
 ## Dependency
-* Altera Quartus Prime 25.1.1
+* Altera Quartus Prime 25.3
 * Supported Board
   - Intel Arria 10 SoC Development Kit
 

--- a/a10_soc_devkit_ghrd_pro/create_ghrd_quartus.tcl
+++ b/a10_soc_devkit_ghrd_pro/create_ghrd_quartus.tcl
@@ -254,6 +254,7 @@ set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files
 set_global_assignment -name SDC_FILE ghrd_timing.sdc
 if {$hps_sgmii == 1} {
 set_global_assignment -name PROGRAMMABLE_POWER_TECHNOLOGY_SETTING "MINIMIZE POWER ONLY"
+set_global_assignment -name OPTIMIZATION_MODE "AGGRESSIVE AREA"
 set_global_assignment -name SDC_FILE hps_sgmii.sdc
 }
 if {$fpga_dp == 1} {


### PR DESCRIPTION
## Release Information:
Quartus Version: 25.3 Build 109 09/24/2025 SC Pro Edition
Tag: QPDS25.3_REL_GSRD_PR
Build: socfpga_ghrd_a10_base/25.3/279

## New Features and Enhancements
None

## Issues Resolved
None

## Latest Known Issues
None