### PR TITLE
## Release Notes for **GHRD for Arria 10 FPGA 26.1**

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,7 @@ $(strip $(2))-package-design: | $(strip $(5))
 
 .PHONY: $(strip $(2))-build
 $(strip $(2))-build: | $(strip $(1))/output_files
-	cd $(strip $(1)) && quartus_syn $(strip $(3))
-	cd $(strip $(1)) && quartus_fit $(strip $(3))
-	cd $(strip $(1)) && quartus_asm $(strip $(3))
-	cd $(strip $(1)) && quartus_sta $(strip $(3)) --mode=finalize
+	cd $(strip $(1)) && quartus_sh --flow compile $(strip $(3)) -c $(strip $(3))
 
 .PHONY: $(strip $(2))-sw-build
 $(strip $(2))-sw-build:

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ This is applicable to all designs.
 ## Advanced feature
 This is only applicable if the feature is enabled.
   - PCIe RootPort IP
-  - SGMII with HPS EMAC and Triple-Speed Ethernet Intel FPGA IP (PHY)
+  - SGMII with HPS EMAC and Triple-Speed Ethernet FPGA IP (PHY)
 
 ## Dependency
-* Altera Quartus Prime 25.3.1
+* Altera Quartus Prime 26.1
 * Supported Board
-  - Intel Arria 10 SoC Development Kit
+  - Arria 10 SoC Development Kit
 
 ## Tested Platform for the GHRD Make flow
 * SUSE Linux Enterprise Server 15 SP4
@@ -51,7 +51,7 @@ This design boots from SD/MMC and has PCIe RootPort IP.
 make a10-soc-devkit-sdmmc-pcie-gen2x8-all
 ```
 ### HPS Serial Gigabit Media Independent Interface (SGMII)
-This design boots from SD/MMC and enabled SGMII with HPS EMAC and Triple-Speed Ethernet Intel FPGA IP (PHY).
+This design boots from SD/MMC and enabled SGMII with HPS EMAC and Triple-Speed Ethernet FPGA IP (PHY).
 ```bash
 make a10-soc-devkit-sdmmc-sgmii-all
 ```

--- a/a10_soc_devkit_ghrd_pro/README.md
+++ b/a10_soc_devkit_ghrd_pro/README.md
@@ -33,7 +33,7 @@ This design boots from SD/MMC and has PCIe RootPort IP.
 make generate-a10-soc-devkit-sdmmc-pcie-gen2x8
 ```
 ### HPS Serial Gigabit Media Independent Interface (SGMII)
-This design boots from SD/MMC and enabled SGMII with HPS EMAC and Triple-Speed Ethernet Intel FPGA IP (PHY).
+This design boots from SD/MMC and enabled SGMII with HPS EMAC and Triple-Speed Ethernet FPGA IP (PHY).
 ```bash
 make generate-a10-soc-devkit-sdmmc-sgmii
 ```
@@ -51,7 +51,7 @@ for more information on HPS EMIF configuration.
 ### HPS-to-FPGA Address Map
 The memory map of soft IP peripherals, as viewed by the microprocessor unit (MPU) of the HPS, starts at HPS-to-FPGA base address of 0xC000_0000.
 
-Refer to [Intel Arria 10 HPS Register Address Map and Definitions](https://www.intel.com/content/www/us/en/programmable/hps/arria-10/hps.html) for details.
+Refer to [Arria 10 HPS Register Address Map and Definitions](https://www.intel.com/content/www/us/en/programmable/hps/arria-10/hps.html) for details.
 
 | Peripheral | Address Offset | Size (bytes) | Attribute |
 | :-- | :-- | :-- | :-- |


### PR DESCRIPTION
## Release Information:
Quartus Version: 26.1 Build 110 03/26/2026 SC Pro Edition
Tag: QPDS26.1_REL_GSRD_PR
Build: socfpga_ghrd_a10_base/26.1/448

## New Features and Enhancements
None

## Issues Resolved
None

## Latest Known Issues
None